### PR TITLE
build(ci): skip Rust CI for documentation-only changes

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -3,8 +3,20 @@ name: Rust
 on:
   push:
     branches: [ "main" ]
+    paths-ignore:
+      - '**.md'
+      - '**.txt'
+      - 'LICENSE'
+      - '.gitignore'
+      - '.gitmessage'
   pull_request:
     branches: [ "main" ]
+    paths-ignore:
+      - '**.md'
+      - '**.txt'
+      - 'LICENSE'
+      - '.gitignore'
+      - '.gitmessage'
 
 env:
   CARGO_TERM_COLOR: always


### PR DESCRIPTION
## Summary

Optimizes CI workflow to skip Rust builds and tests when only documentation files are modified.

## Changes

- Added `paths-ignore` configuration to `.github/workflows/rust.yml`
- Workflow now skips for changes to:
  - Markdown files (`**.md`)
  - Text files (`**.txt`)
  - LICENSE, .gitignore, .gitmessage

## Benefits

- ✅ Saves CI minutes on documentation updates
- ✅ Faster feedback loop for docs changes
- ✅ Workflow still runs for all code changes

## Testing

The workflow will be tested automatically when this PR is opened. Since this PR only modifies the workflow file itself (not docs-only), CI should run and validate the configuration is correct.